### PR TITLE
feat(scanner): Améliore la détection des bibliothèques JS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ sslyze
 dnspython
 beautifulsoup4
 packaging
+lxml

--- a/security_checker.py
+++ b/security_checker.py
@@ -221,7 +221,7 @@ def check_js_libraries(hostname):
     try:
         response = requests.get(f"https://{hostname}", timeout=10); soup = BeautifulSoup(response.content, 'lxml')
         for script in soup.find_all('script', src=True):
-            src = script['src']; match = re.search(r'([a-zA-Z0-9.-]+)-([0-9]+\.[0-9]+\.[0-9]+)(.min)?\.js', src)
+            src = script['src']; match = re.search(r'([a-zA-Z0-9.-]+)[._-]([0-9]+(?:\.[0-9]+)*)(?:[._-]min)?\.js', src)
             if match:
                 lib_name = match.group(1).lower(); detected_version_str = match.group(2)
                 if lib_name in KNOWN_JS_LIBRARIES:


### PR DESCRIPTION
La regex utilisée pour détecter les bibliothèques JavaScript était trop stricte et ne reconnaissait que les versions séparées par des tirets. Elle a été remplacée par une expression plus flexible qui accepte également les points comme séparateurs, ce qui augmente la compatibilité avec de nombreux sites.

fix(deps): Ajoute la dépendance lxml manquante

Le script nécessitait la bibliothèque `lxml` pour l'analyse avec BeautifulSoup, mais elle n'était pas listée dans `requirements.txt`. Elle a été ajoutée pour éviter les erreurs d'exécution.