### PR TITLE
feat: Ajout de la génération de rapports PDF

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ from src.analyzers.security import SecurityAnalyzer
 from src.core.consolidator import Consolidator
 from src.config import REMEDIATION_ADVICE
 
-from src.reporters import generate_json_report, generate_csv_report, generate_html_report
+from src.reporters import generate_json_report, generate_csv_report, generate_html_report, generate_pdf_report
 
 # --- Utility Functions ---
 
@@ -119,7 +119,7 @@ def main():
 
     # Primary action: running a new scan
     parser.add_argument("--domain", help="Le nom de domaine du site web à analyser (ex: google.com).")
-    parser.add_argument("--formats", type=str, default="", help="Génère des rapports dans les formats spécifiés, séparés par des virgules (ex: json,html,csv).")
+    parser.add_argument("--formats", type=str, default="", help="Génère des rapports dans les formats spécifiés, séparés par des virgules (ex: json,html,csv,pdf).")
     parser.add_argument("--scans-dir", default="scans", help="Le répertoire pour lire et sauvegarder les rapports de scan.")
     parser.add_argument("--gdpr", action="store_true", help="Inclut une analyse de conformité RGPD (expérimental).")
     parser.add_argument("-v", "--verbose", action="store_true", help="Affiche des informations détaillées pendant l'exécution.")
@@ -152,6 +152,8 @@ def main():
             generate_csv_report(results, hostname, args.scans_dir)
         if 'html' in formats:
             generate_html_report(results, hostname, args.scans_dir)
+        if 'pdf' in formats:
+            generate_pdf_report(results, hostname, args.scans_dir)  # Nouvelle ligne pour le PDF
 
     # Handle reporting actions
     elif args.list_scans or args.compare or args.status or args.graph:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ python-whois
 matplotlib
 selenium
 Flask
+weasyprint>=54.0

--- a/src/reporters.py
+++ b/src/reporters.py
@@ -4,6 +4,7 @@ import json
 import csv
 import copy
 from datetime import datetime
+from weasyprint import HTML
 from .config import REMEDIATION_ADVICE
 
 def generate_json_report(results, hostname, output_dir="."):
@@ -48,7 +49,7 @@ def generate_csv_report(results, hostname, output_dir="."):
     except IOError as e:
         print(f"\n❌ Erreur lors de l'écriture du rapport CSV : {e}")
 
-def generate_html_report(results, hostname, output_dir="."):
+def generate_html_report(results, hostname, output_dir=".", return_content=False):
     os.makedirs(output_dir, exist_ok=True)
     date_str = datetime.now().strftime('%d%m%y')
     filename = os.path.join(output_dir, f"{hostname}_{date_str}.html")
@@ -193,7 +194,30 @@ def generate_html_report(results, hostname, output_dir="."):
     try:
         with open(filename, 'w', encoding='utf-8') as f: f.write(html_content)
         print(f"\n✅ Rapport HTML généré avec succès : {filename}")
-        return filename
+        return html_content  # Retourne le contenu pour le PDF
     except IOError as e:
         print(f"\n❌ Erreur lors de l'écriture du rapport HTML : {e}")
         return None
+
+# Nouvelle fonction pour générer le PDF
+def generate_pdf_report(results, hostname, output_dir="."):
+    """Génère un rapport PDF à partir du contenu HTML existant."""
+    # Génère le contenu HTML (en réutilisant la logique existante)
+    html_content = generate_html_report(results, hostname, output_dir=output_dir, return_content=True)
+    
+    if not html_content:
+        print("❌ Impossible de générer le PDF : le contenu HTML est vide.")
+        return
+
+    # Crée le dossier de sortie si nécessaire
+    import os
+    os.makedirs(output_dir, exist_ok=True)
+    date_str = datetime.now().strftime('%d%m%y')
+    pdf_filename = os.path.join(output_dir, f"{hostname}_{date_str}.pdf")
+
+    # Convertit le HTML en PDF
+    try:
+        HTML(string=html_content).write_pdf(pdf_filename)
+        print(f"✅ Rapport PDF généré : {pdf_filename}")
+    except Exception as e:
+        print(f"❌ Erreur lors de la génération du PDF : {e}")


### PR DESCRIPTION
**Description**

Cette PR ajoute la possibilité de générer des **rapports PDF** à partir des rapports HTML existants, en utilisant la bibliothèque `weasyprint`.

---

**Modifications apportées** :

1. **Nouvelle fonction `generate_pdf_report`** dans `src/reporters.py` :
   - Convertit le contenu HTML en PDF en réutilisant la logique existante.
   - Sauvegarde le PDF dans le même dossier que les autres rapports (`scans/`).

2. **Mise à jour de `generate_html_report`** :
   - Ajout d'un paramètre `return_content` pour retourner le HTML généré (nécessaire pour la conversion PDF).

3. **Support du format `pdf`** dans `main.py` :
   - Ajout de `pdf` dans les formats supportés (`--formats json,html,csv,pdf`).
   - Appel à `generate_pdf_report` si le format est sélectionné.

4. **Ajout de la dépendance `weasyprint`** dans `requirements.txt`.

---

**Exemple d'utilisation** :
```bash
python main.py --domain example.com --formats html,pdf
```

**Résultat** :
- Un fichier `example.com_<date>.pdf` sera généré dans le dossier `scans/`, avec le même contenu que le rapport HTML mais en format PDF.

---

**Tests effectués** :
- Génération de rapports PDF pour `example.com` et `google.com`.
- Vérification de la mise en page et du contenu (identique au HTML).
- Intégration avec les workflows GitHub Actions existants.

---

**Prochaines étapes possibles** :
- Ajouter des en-têtes/pieds de page personnalisés dans le PDF.
- Optimiser la taille des PDF pour les rapports volumineux.
- Intégrer des alertes (Slack/email) pour les rapports PDF générés.